### PR TITLE
feat: detect Vite+ projects and launch `vp lint/fmt --lsp` (POC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Configuration is managed in your `.zed/settings.json` file. Examples are availab
 
 See https://github.com/oxc-project/oxc/tree/main/crates/oxc_language_server for the options that are supported by the language server.
 
+### Vite+ projects
+
+When a workspace declares [`vite-plus`](https://github.com/voidzero-dev/vite-plus), this extension launches `vp lint --lsp` / `vp fmt --lsp` instead of plain `oxlint` / `oxfmt`. In that mode `vp` resolves the lint and format configuration from your Vite config, so the `configPath` (oxlint) and `fmt.configPath` (oxfmt) settings are **ignored**. The other LSP settings (`run`, `fixKind`, `disableNestedConfig`, `unusedDisableDirectives`) still apply.
+
 ## ❤ Who's [Sponsoring Oxc](https://github.com/sponsors/Boshen)?
 
 <p align="center">

--- a/examples/both/.zed/settings.json
+++ b/examples/both/.zed/settings.json
@@ -3,6 +3,7 @@
     "oxlint": {
       "initialization_options": {
         "settings": {
+          // Ignored in Vite+ projects: `vp` resolves lint config from your Vite config.
           "configPath": null,
           "run": "onType",
           "disableNestedConfig": false,
@@ -14,6 +15,7 @@
     "oxfmt": {
       "initialization_options": {
         "settings": {
+          // Ignored in Vite+ projects: `vp` resolves format config from your Vite config.
           "fmt.configPath": null,
           "run": "onSave"
         }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -191,7 +191,7 @@ fn package_exists(package_json: &Value, package_name: &str) -> bool {
 /// Zed's WASM API can only read files inside the worktree, relative to its
 /// root, so absolute paths are translated to worktree-relative ones and any
 /// path above the root resolves to "missing". This naturally bounds the
-/// detector's upward walk at the worktree root — the single-root limitation
+/// detector's upward walk at the worktree root, the single-root limitation
 /// noted in the RFC.
 pub struct WorktreeFs<'a> {
     worktree: &'a Worktree,
@@ -222,7 +222,7 @@ impl FileSystem for WorktreeFs<'_> {
     fn can_read_node_modules(&self) -> bool {
         // Reads inside node_modules are unreliable in Zed's WASM sandbox
         // (zed#10760), so the detector trusts the conventional vp path rather
-        // than read-verifying it — matching how this extension already
+        // than read-verifying it, matching how this extension already
         // resolves oxlint/oxfmt.
         false
     }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,11 +1,12 @@
+use crate::vite_plus::{DetectResult, FileSystem, detect_vite_plus_project};
 use log::debug;
 use std::env;
 use std::path::{Path, PathBuf};
 use zed_extension_api::serde_json::{Value, from_str};
 use zed_extension_api::{
     Command, LanguageServerId, LanguageServerInstallationStatus, Result, Worktree,
-    npm_install_package, npm_package_installed_version, npm_package_latest_version,
-    set_language_server_installation_status,
+    node_binary_path, npm_install_package, npm_package_installed_version,
+    npm_package_latest_version, set_language_server_installation_status,
 };
 
 pub const OXLINT_SERVER_ID: &str = "oxlint";
@@ -25,21 +26,79 @@ pub trait ZedLspSupport: Send + Sync {
         let workspace_root_path = worktree.root_path();
         let workspace_root = Path::new(workspace_root_path.as_str());
 
-        for package_dir in [package_name.as_str(), "vite-plus"] {
-            if package_json
-                .as_ref()
-                .is_some_and(|package_json| package_exists(package_json, package_dir))
-            {
-                return self
-                    .get_exe_path_from(workspace_root, package_dir, package_name.as_str())
-                    .map(Some);
-            }
+        // Vite+ detection is handled separately (see `detect_vite_plus`); this
+        // only locates a plain oxlint/oxfmt install declared at the worktree root.
+        if package_json
+            .as_ref()
+            .is_some_and(|package_json| package_exists(package_json, package_name.as_str()))
+        {
+            return self
+                .get_exe_path_from(workspace_root, package_name.as_str(), package_name.as_str())
+                .map(Some);
         }
 
         Ok(None)
     }
 
+    /// Run the Vite+ detector against this worktree. Returns `None` when the
+    /// project is not Vite+; see [`DetectResult`] for the two `Some` cases.
+    fn detect_vite_plus(&self, worktree: &Worktree) -> Option<DetectResult> {
+        let root = worktree.root_path();
+        let fs = WorktreeFs::new(worktree);
+        detect_vite_plus_project(&fs, Path::new(root.as_str()))
+    }
+
+    /// The `vp` subcommand this language server maps to (`lint` / `fmt`).
+    fn vite_plus_subcommand(&self) -> &'static str;
+
+    /// Resolve the `(command, args)` to launch the language server, choosing
+    /// `vp <subcommand> --lsp` for a runnable Vite+ project and plain
+    /// `<tool> --lsp` otherwise.
+    fn resolve_lsp_invocation(&self, worktree: &Worktree) -> Result<(String, Vec<String>)> {
+        if let Some(result) = self.detect_vite_plus(worktree) {
+            if let Some(vp_path) = result.vp_path {
+                debug!(
+                    "Vite+ project detected at {:?}; launching {vp_path:?}",
+                    result.root
+                );
+                return Ok((
+                    node_binary_path()?,
+                    vec![
+                        vp_path.to_string_lossy().to_string(),
+                        self.vite_plus_subcommand().to_string(),
+                        "--lsp".to_string(),
+                    ],
+                ));
+            }
+            // Declared but not installed: no runnable `vp` reachable. Fall back
+            // to plain oxlint/oxfmt rather than spawning a bare `vp`.
+            debug!(
+                "Vite+ declared at {:?} but no runnable vp found; falling back to plain {}",
+                result.root,
+                self.get_package_name(),
+            );
+        }
+
+        Ok((
+            node_binary_path()?,
+            vec![
+                self.get_resolved_exe_path(worktree)?
+                    .to_string_lossy()
+                    .to_string(),
+                "--lsp".to_string(),
+            ],
+        ))
+    }
+
     fn exe_exists(&self, worktree: &Worktree) -> Result<bool> {
+        // A runnable Vite+ project supplies its own `vp`; the extension does
+        // not need to download oxlint/oxfmt from npm in that case.
+        if let Some(DetectResult {
+            vp_path: Some(_), ..
+        }) = self.detect_vite_plus(worktree)
+        {
+            return Ok(true);
+        }
         Ok(self.get_workspace_exe_path(worktree)?.is_some())
     }
 
@@ -125,4 +184,44 @@ pub trait ZedLspSupport: Send + Sync {
 fn package_exists(package_json: &Value, package_name: &str) -> bool {
     !package_json["dependencies"][package_name].is_null()
         || !package_json["devDependencies"][package_name].is_null()
+}
+
+/// [`FileSystem`] backed by a Zed [`Worktree`].
+///
+/// Zed's WASM API can only read files inside the worktree, relative to its
+/// root, so absolute paths are translated to worktree-relative ones and any
+/// path above the root resolves to "missing". This naturally bounds the
+/// detector's upward walk at the worktree root — the single-root limitation
+/// noted in the RFC.
+pub struct WorktreeFs<'a> {
+    worktree: &'a Worktree,
+    root: PathBuf,
+}
+
+impl<'a> WorktreeFs<'a> {
+    pub fn new(worktree: &'a Worktree) -> Self {
+        let root = PathBuf::from(worktree.root_path());
+        Self { worktree, root }
+    }
+}
+
+impl FileSystem for WorktreeFs<'_> {
+    fn read_text_file(&self, path: &Path) -> Option<String> {
+        let rel = path.strip_prefix(&self.root).ok()?;
+        self.worktree
+            .read_text_file(rel.to_string_lossy().as_ref())
+            .ok()
+    }
+
+    fn file_exists(&self, path: &Path) -> bool {
+        // The API exposes no stat; a successful text read is our existence
+        // probe. `bin/vp` and the marker files are small text launchers.
+        self.read_text_file(path).is_some()
+    }
+
+    fn which(&self, binary: &str) -> Option<PathBuf> {
+        // Zed *does* expose a `$PATH` lookup, contrary to the RFC's note that
+        // Phase 3 is unimplementable here.
+        self.worktree.which(binary).map(PathBuf::from)
+    }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -224,4 +224,12 @@ impl FileSystem for WorktreeFs<'_> {
         // Phase 3 is unimplementable here.
         self.worktree.which(binary).map(PathBuf::from)
     }
+
+    fn can_read_node_modules(&self) -> bool {
+        // Reads inside node_modules are unreliable in Zed's WASM sandbox
+        // (zed#10760), so the detector trusts the conventional vp path rather
+        // than read-verifying it — matching how this extension already
+        // resolves oxlint/oxfmt.
+        false
+    }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -219,12 +219,6 @@ impl FileSystem for WorktreeFs<'_> {
         self.read_text_file(path).is_some()
     }
 
-    fn which(&self, binary: &str) -> Option<PathBuf> {
-        // Zed *does* expose a `$PATH` lookup, contrary to the RFC's note that
-        // Phase 3 is unimplementable here.
-        self.worktree.which(binary).map(PathBuf::from)
-    }
-
     fn can_read_node_modules(&self) -> bool {
         // Reads inside node_modules are unreliable in Zed's WASM sandbox
         // (zed#10760), so the detector trusts the conventional vp path rather

--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -1,6 +1,7 @@
 mod lsp;
 mod oxfmt;
 mod oxlint;
+mod vite_plus;
 
 use crate::lsp::{OXFMT_SERVER_ID, OXLINT_SERVER_ID, ZedLspSupport};
 use crate::oxfmt::ZedOxfmtLsp;

--- a/src/oxfmt.rs
+++ b/src/oxfmt.rs
@@ -2,7 +2,7 @@ use crate::lsp::ZedLspSupport;
 use log::debug;
 use zed_extension_api::serde_json::Value;
 use zed_extension_api::settings::LspSettings;
-use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree, node_binary_path};
+use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree};
 
 pub struct ZedOxfmtLsp {}
 
@@ -17,6 +17,10 @@ impl ZedLspSupport for ZedOxfmtLsp {
         "oxfmt".to_string()
     }
 
+    fn vite_plus_subcommand(&self) -> &'static str {
+        "fmt"
+    }
+
     fn language_server_command(
         &self,
         language_server_id: &LanguageServerId,
@@ -25,13 +29,7 @@ impl ZedLspSupport for ZedOxfmtLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxfmt language_server_command LspSettings: {settings:?}");
 
-        let mut args = vec![
-            self.get_resolved_exe_path(worktree)?
-                .to_string_lossy()
-                .to_string(),
-            "--lsp".to_string(),
-        ];
-        let mut command = node_binary_path()?;
+        let (mut command, mut args) = self.resolve_lsp_invocation(worktree)?;
         let mut env = EnvVars::default();
         if let Some(binary) = settings.binary {
             if (binary.path.is_some() && binary.arguments.is_none())

--- a/src/oxlint.rs
+++ b/src/oxlint.rs
@@ -3,7 +3,7 @@ use log::debug;
 use std::path::{Path, PathBuf};
 use zed_extension_api::serde_json::Value;
 use zed_extension_api::settings::LspSettings;
-use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree, node_binary_path};
+use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree};
 
 pub struct ZedOxlintLsp {}
 
@@ -18,6 +18,10 @@ impl ZedLspSupport for ZedOxlintLsp {
         "oxlint".to_string()
     }
 
+    fn vite_plus_subcommand(&self) -> &'static str {
+        "lint"
+    }
+
     fn language_server_command(
         &self,
         language_server_id: &LanguageServerId,
@@ -26,13 +30,7 @@ impl ZedLspSupport for ZedOxlintLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxlint language_server_command LspSettings: {settings:?}");
 
-        let mut args = vec![
-            self.get_resolved_exe_path(worktree)?
-                .to_string_lossy()
-                .to_string(),
-            "--lsp".to_string(),
-        ];
-        let mut command = node_binary_path()?;
+        let (mut command, mut args) = self.resolve_lsp_invocation(worktree)?;
         let mut env = EnvVars::default();
         if let Some(binary) = settings.binary {
             if (binary.path.is_some() && binary.arguments.is_none())

--- a/src/vite_plus.rs
+++ b/src/vite_plus.rs
@@ -1,0 +1,403 @@
+//! Vite+ project detection.
+//!
+//! Portable implementation of the rule defined in the Vite+ RFC
+//! *"Vite+ Project Detection for Editor Extensions"*
+//! ([voidzero-dev/vite-plus#1614]). A workspace is **Vite+** iff some
+//! walked-up `package.json` directly declares `vite-plus` in `dependencies`
+//! or `devDependencies`, bounded by the root workspace. The runnable `vp`
+//! binary is resolved separately, also bounded by the root workspace, and
+//! validated against a real `vite-plus` package (`name === "vite-plus"`).
+//!
+//! The core logic is intentionally free of any `zed_extension_api` resource
+//! type so it can be unit-tested against the RFC conformance fixtures on the
+//! host. At runtime the Zed extension backs the [`FileSystem`] trait with a
+//! `Worktree` (see [`crate::lsp::WorktreeFs`]).
+//!
+//! [voidzero-dev/vite-plus#1614]: https://github.com/voidzero-dev/vite-plus/pull/1614
+
+use std::path::{Path, PathBuf};
+use zed_extension_api::serde_json::{Value, from_str};
+
+/// Filesystem operations the detector needs.
+///
+/// Paths handed to these methods are absolute. The Zed adapter translates
+/// them to worktree-relative reads and returns `None`/`false` for anything
+/// outside the worktree (Zed's WASM API cannot read above the worktree root).
+pub trait FileSystem {
+    /// Returns the textual contents of the file at `path`, or `None` when it
+    /// does not exist or cannot be read.
+    fn read_text_file(&self, path: &Path) -> Option<String>;
+
+    /// Whether a regular file exists at `path`.
+    fn file_exists(&self, path: &Path) -> bool;
+
+    /// Resolves a binary by name on `$PATH` (RFC Phase 3). `None` when the
+    /// binary is absent or `$PATH` lookup is unavailable in this environment.
+    fn which(&self, binary: &str) -> Option<PathBuf>;
+}
+
+/// Outcome of [`detect_vite_plus_project`].
+///
+/// Mirrors the RFC's `{ root: string; vpPath?: string } | null`:
+/// - `None` (from the detector) — not a Vite+ project.
+/// - `Some` with `vp_path = Some(_)` — Vite+ and runnable.
+/// - `Some` with `vp_path = None` — declared but no usable `vp` (install hint).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectResult {
+    /// The ancestor whose `package.json` directly declares `vite-plus`.
+    pub root: PathBuf,
+    /// The runnable `vp` launcher, when one was found.
+    pub vp_path: Option<PathBuf>,
+}
+
+fn read_package_json<F: FileSystem>(fs: &F, dir: &Path) -> Option<Value> {
+    let contents = fs.read_text_file(&dir.join("package.json"))?;
+    from_str(&contents).ok()
+}
+
+fn declares_vite_plus(pkg: &Value) -> bool {
+    !pkg["dependencies"]["vite-plus"].is_null() || !pkg["devDependencies"]["vite-plus"].is_null()
+}
+
+/// A directory is a *root workspace* (monorepo root) if it carries a
+/// `pnpm-workspace.yaml`, a `lerna.json`, or a `package.json` with a
+/// top-level `workspaces` field. Mirrors `findWorkspaceRoot` in vite-plus.
+fn is_root_workspace<F: FileSystem>(fs: &F, dir: &Path, pkg: Option<&Value>) -> bool {
+    if fs.file_exists(&dir.join("pnpm-workspace.yaml")) {
+        return true;
+    }
+    if fs.file_exists(&dir.join("lerna.json")) {
+        return true;
+    }
+    pkg.is_some_and(|pkg| !pkg["workspaces"].is_null())
+}
+
+/// Probe `dir/node_modules/vite-plus/bin/vp`, validated against that
+/// package's own `package.json` (`name === "vite-plus"`).
+///
+/// Zed targets the real package launcher rather than the package manager's
+/// `node_modules/.bin/vp` shell shim, because pnpm stores bash scripts there
+/// that are not usable from Zed's headless WASM execution context.
+fn resolve_vp_at<F: FileSystem>(fs: &F, dir: &Path) -> Option<PathBuf> {
+    let pkg_dir = dir.join("node_modules").join("vite-plus");
+    let bin = pkg_dir.join("bin").join("vp");
+    if !fs.file_exists(&bin) {
+        return None;
+    }
+    let manifest = read_package_json(fs, &pkg_dir)?;
+    (manifest["name"].as_str() == Some("vite-plus")).then_some(bin)
+}
+
+/// Walks `dir` up to the filesystem root, returning each ancestor and a flag
+/// telling whether that ancestor is itself the root workspace (the bound: we
+/// visit the root workspace, then stop). The first read `package.json` is
+/// surfaced so the caller can avoid re-reading it.
+fn walk_up<F, T>(
+    fs: &F,
+    start: &Path,
+    mut visit: impl FnMut(&Path, Option<&Value>) -> Step<T>,
+) -> Option<T>
+where
+    F: FileSystem,
+{
+    let mut dir = start.to_path_buf();
+    loop {
+        let pkg = read_package_json(fs, &dir);
+        match visit(&dir, pkg.as_ref()) {
+            Step::Found(value) => return Some(value),
+            Step::Continue => {}
+        }
+        // Stop *at* the root workspace; never cross into its parent.
+        if is_root_workspace(fs, &dir, pkg.as_ref()) {
+            return None;
+        }
+        match dir.parent() {
+            Some(parent) if parent != dir => dir = parent.to_path_buf(),
+            _ => return None,
+        }
+    }
+}
+
+enum Step<T> {
+    Found(T),
+    Continue,
+}
+
+/// Detects whether `start` lives in a Vite+ project and, if so, locates a
+/// runnable `vp`. Implements the three RFC phases:
+///
+/// 1. Walk up from `start` to the root workspace looking for the first
+///    `package.json` that directly declares `vite-plus`. If none, return
+///    `None` (not Vite+).
+/// 2. Walk up from that declaring directory (again bounded by the root
+///    workspace) for a project-scoped `node_modules/vite-plus/bin/vp`.
+/// 3. Fall back to a `vp` on `$PATH` now that Vite+ is confirmed.
+///
+/// Returns `Some(DetectResult { root, vp_path })`; `vp_path` is `None` when
+/// `vite-plus` is declared but no runnable `vp` exists anywhere reachable.
+pub fn detect_vite_plus_project<F: FileSystem>(fs: &F, start: &Path) -> Option<DetectResult> {
+    // Phase 1: find the package.json that DIRECTLY declares vite-plus.
+    let root = walk_up(fs, start, |dir, pkg| {
+        if pkg.is_some_and(declares_vite_plus) {
+            Step::Found(dir.to_path_buf())
+        } else {
+            Step::Continue
+        }
+    })?;
+
+    // Phase 2: resolve a project-scoped binary, bounded by the root workspace.
+    let vp_path = walk_up(fs, &root, |dir, _| match resolve_vp_at(fs, dir) {
+        Some(vp) => Step::Found(vp),
+        None => Step::Continue,
+    });
+    if let Some(vp_path) = vp_path {
+        return Some(DetectResult {
+            root,
+            vp_path: Some(vp_path),
+        });
+    }
+
+    // Phase 3: fall back to a global vp now that Vite+ is confirmed.
+    // Unlike the RFC's note, Zed *can* do this: `Worktree::which` exposes a
+    // `$PATH` lookup. See the module-level docs.
+    if let Some(vp) = fs.which("vp") {
+        return Some(DetectResult {
+            root,
+            vp_path: Some(vp),
+        });
+    }
+
+    Some(DetectResult {
+        root,
+        vp_path: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// In-memory filesystem for the conformance fixtures. A path is present
+    /// in `files` iff it exists; readable files also carry contents. `which`
+    /// models a `vp` on `$PATH`.
+    #[derive(Default)]
+    struct FakeFs {
+        files: BTreeMap<PathBuf, String>,
+        path_vp: Option<PathBuf>,
+    }
+
+    impl FakeFs {
+        fn file(mut self, path: &str, contents: &str) -> Self {
+            self.files.insert(PathBuf::from(path), contents.to_string());
+            self
+        }
+
+        /// A package.json declaring vite-plus as a devDependency.
+        fn declares(self, dir: &str) -> Self {
+            self.file(
+                &format!("{dir}/package.json"),
+                r#"{ "devDependencies": { "vite-plus": "^1.0.0" } }"#,
+            )
+        }
+
+        /// A valid installed vite-plus package at `<dir>/node_modules/vite-plus`.
+        fn install(self, dir: &str) -> Self {
+            self.file(
+                &format!("{dir}/node_modules/vite-plus/bin/vp"),
+                "#!/usr/bin/env node\n",
+            )
+            .file(
+                &format!("{dir}/node_modules/vite-plus/package.json"),
+                r#"{ "name": "vite-plus", "version": "1.0.0" }"#,
+            )
+        }
+
+        fn marker(self, dir: &str, file: &str) -> Self {
+            self.file(&format!("{dir}/{file}"), "")
+        }
+
+        fn vp_on_path(mut self, path: &str) -> Self {
+            self.path_vp = Some(PathBuf::from(path));
+            self
+        }
+    }
+
+    impl FileSystem for FakeFs {
+        fn read_text_file(&self, path: &Path) -> Option<String> {
+            self.files.get(path).cloned()
+        }
+
+        fn file_exists(&self, path: &Path) -> bool {
+            self.files.contains_key(path)
+        }
+
+        fn which(&self, binary: &str) -> Option<PathBuf> {
+            (binary == "vp").then(|| self.path_vp.clone()).flatten()
+        }
+    }
+
+    fn detect(fs: &FakeFs, start: &str) -> Option<DetectResult> {
+        detect_vite_plus_project(fs, Path::new(start))
+    }
+
+    fn runnable(root: &str, vp: &str) -> Option<DetectResult> {
+        Some(DetectResult {
+            root: PathBuf::from(root),
+            vp_path: Some(PathBuf::from(vp)),
+        })
+    }
+
+    fn declared_only(root: &str) -> Option<DetectResult> {
+        Some(DetectResult {
+            root: PathBuf::from(root),
+            vp_path: None,
+        })
+    }
+
+    // -- RFC conformance fixtures ------------------------------------------
+
+    #[test]
+    fn root_declared_and_installed() {
+        let fs = FakeFs::default().declares("/repo").install("/repo");
+        assert_eq!(
+            detect(&fs, "/repo"),
+            runnable("/repo", "/repo/node_modules/vite-plus/bin/vp")
+        );
+    }
+
+    #[test]
+    fn pnpm_subpackage_declared_root_hoisted() {
+        let fs = FakeFs::default()
+            .marker("/repo", "pnpm-workspace.yaml")
+            .file("/repo/package.json", "{}")
+            .declares("/repo/packages/app")
+            .install("/repo"); // hoisted to the workspace root
+        assert_eq!(
+            detect(&fs, "/repo/packages/app"),
+            runnable("/repo/packages/app", "/repo/node_modules/vite-plus/bin/vp"),
+        );
+    }
+
+    #[test]
+    fn npm_subpackage_direct_dep_unhoisted() {
+        let fs = FakeFs::default()
+            .file("/repo/package.json", r#"{ "workspaces": ["packages/*"] }"#)
+            .declares("/repo/packages/app")
+            .install("/repo/packages/app"); // unhoisted, local to the subpackage
+        assert_eq!(
+            detect(&fs, "/repo/packages/app"),
+            runnable(
+                "/repo/packages/app",
+                "/repo/packages/app/node_modules/vite-plus/bin/vp"
+            ),
+        );
+    }
+
+    #[test]
+    fn root_declared_no_local_no_global() {
+        let fs = FakeFs::default().declares("/repo");
+        assert_eq!(detect(&fs, "/repo"), declared_only("/repo"));
+    }
+
+    #[test]
+    fn root_declared_no_local_global_on_path() {
+        let fs = FakeFs::default()
+            .declares("/repo")
+            .vp_on_path("/usr/local/bin/vp");
+        assert_eq!(detect(&fs, "/repo"), runnable("/repo", "/usr/local/bin/vp"));
+    }
+
+    #[test]
+    fn transitive_install() {
+        // node_modules/vite-plus exists but no package.json declares it.
+        let fs = FakeFs::default()
+            .file("/repo/package.json", "{}")
+            .install("/repo");
+        assert_eq!(detect(&fs, "/repo"), None);
+    }
+
+    #[test]
+    fn global_vp_without_declaration() {
+        // Phase 1 fails, so Phase 3 (the $PATH vp) must never run.
+        let fs = FakeFs::default()
+            .file("/repo/package.json", "{}")
+            .vp_on_path("/usr/local/bin/vp");
+        assert_eq!(detect(&fs, "/repo"), None);
+    }
+
+    #[test]
+    fn parent_vite_plus_nested_repo() {
+        // Outer repo declares + installs vite-plus; the inner directory is its
+        // own root workspace and does not. Detection must not cross the bound.
+        let fs = FakeFs::default()
+            .declares("/repo")
+            .install("/repo")
+            .marker("/repo/nested", "pnpm-workspace.yaml")
+            .file("/repo/nested/package.json", "{}");
+        assert_eq!(detect(&fs, "/repo/nested"), None);
+    }
+
+    #[test]
+    fn plain_non_vite_plus() {
+        let fs = FakeFs::default().file("/repo/package.json", r#"{ "dependencies": {} }"#);
+        assert_eq!(detect(&fs, "/repo"), None);
+    }
+
+    #[test]
+    fn yarn4_pnp() {
+        // Berry/PnP: declared, but no node_modules and no global vp.
+        let fs = FakeFs::default().declares("/repo");
+        assert_eq!(detect(&fs, "/repo"), declared_only("/repo"));
+    }
+
+    // -- Zed-specific runtime boundary -------------------------------------
+
+    #[test]
+    fn zed_worktree_root_misses_subpackage_declaration() {
+        // Zed's start path is always the worktree root and it cannot read
+        // above it. When a user opens the monorepo root but only a subpackage
+        // declares vite-plus, Phase 1 stops at the root-workspace marker and
+        // returns null. This is the acknowledged single-root limitation.
+        let fs = FakeFs::default()
+            .marker("/repo", "pnpm-workspace.yaml")
+            .file("/repo/package.json", "{}")
+            .declares("/repo/packages/app")
+            .install("/repo");
+        assert_eq!(detect(&fs, "/repo"), None);
+    }
+
+    #[test]
+    fn stale_install_without_valid_manifest_is_not_runnable() {
+        // bin/vp present but the package.json doesn't validate as vite-plus.
+        let fs = FakeFs::default()
+            .declares("/repo")
+            .file(
+                "/repo/node_modules/vite-plus/bin/vp",
+                "#!/usr/bin/env node\n",
+            )
+            .file(
+                "/repo/node_modules/vite-plus/package.json",
+                r#"{ "name": "imposter" }"#,
+            );
+        assert_eq!(detect(&fs, "/repo"), declared_only("/repo"));
+    }
+
+    #[test]
+    fn phase2_walks_up_to_intermediate_install() {
+        // Declared in a deep subpackage; install hoisted to an intermediate
+        // (non-root) directory. Phase 2 must find it on the way up.
+        let fs = FakeFs::default()
+            .file("/repo/package.json", r#"{ "workspaces": ["packages/*"] }"#)
+            .file("/repo/packages/app/package.json", "{}")
+            .declares("/repo/packages/app/sub")
+            .install("/repo/packages/app");
+        assert_eq!(
+            detect(&fs, "/repo/packages/app/sub"),
+            runnable(
+                "/repo/packages/app/sub",
+                "/repo/packages/app/node_modules/vite-plus/bin/vp"
+            ),
+        );
+    }
+}

--- a/src/vite_plus.rs
+++ b/src/vite_plus.rs
@@ -36,7 +36,7 @@ pub trait FileSystem {
     /// Zed's WASM API cannot reliably read there ([zed#10760]) and `Path::exists`
     /// does not work in the sandbox, so when this returns `false` the detector
     /// trusts the conventional `node_modules/vite-plus/bin/vp` path instead of
-    /// read-verifying the install — exactly what the shipping extension already
+    /// read-verifying the install, exactly what the shipping extension already
     /// does for `oxlint`/`oxfmt`. A missing install then surfaces as a
     /// spawn-time error (the RFC's anticipated "upgrade hint" trigger).
     ///
@@ -49,9 +49,9 @@ pub trait FileSystem {
 /// Outcome of [`detect_vite_plus_project`].
 ///
 /// Mirrors the RFC's `{ root: string; vpPath?: string } | null`:
-/// - `None` (from the detector) — not a Vite+ project.
-/// - `Some` with `vp_path = Some(_)` — Vite+ and runnable.
-/// - `Some` with `vp_path = None` — declared but no usable `vp` (install hint).
+/// - `None` (from the detector): not a Vite+ project.
+/// - `Some` with `vp_path = Some(_)`: Vite+ and runnable.
+/// - `Some` with `vp_path = None`: declared but no usable `vp` (install hint).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DetectResult {
     /// The ancestor whose `package.json` directly declares `vite-plus`.
@@ -183,7 +183,7 @@ pub fn detect_vite_plus_project<F: FileSystem>(fs: &F, start: &Path) -> Option<D
         // Zed: node_modules reads are unreliable, so trust the conventional
         // path at the declaring directory. We cannot probe ancestors for a
         // hoisted install (no reliable existence check), so we target the
-        // declaring directory only — the same `<root>/node_modules/...` path
+        // declaring directory only, the same `<root>/node_modules/...` path
         // the extension uses today.
         Some(vp_launcher_path(&root))
     };

--- a/src/vite_plus.rs
+++ b/src/vite_plus.rs
@@ -34,6 +34,20 @@ pub trait FileSystem {
     /// Resolves a binary by name on `$PATH` (RFC Phase 3). `None` when the
     /// binary is absent or `$PATH` lookup is unavailable in this environment.
     fn which(&self, binary: &str) -> Option<PathBuf>;
+
+    /// Whether reads inside `node_modules` are reliable.
+    ///
+    /// Zed's WASM API cannot reliably read there ([zed#10760]) and `Path::exists`
+    /// does not work in the sandbox, so when this returns `false` the detector
+    /// trusts the conventional `node_modules/vite-plus/bin/vp` path instead of
+    /// read-verifying the install — exactly what the shipping extension already
+    /// does for `oxlint`/`oxfmt`. A missing install then surfaces as a
+    /// spawn-time error (the RFC's anticipated "upgrade hint" trigger).
+    ///
+    /// [zed#10760]: https://github.com/zed-industries/zed/issues/10760
+    fn can_read_node_modules(&self) -> bool {
+        true
+    }
 }
 
 /// Outcome of [`detect_vite_plus_project`].
@@ -72,18 +86,27 @@ fn is_root_workspace<F: FileSystem>(fs: &F, dir: &Path, pkg: Option<&Value>) -> 
     pkg.is_some_and(|pkg| !pkg["workspaces"].is_null())
 }
 
-/// Probe `dir/node_modules/vite-plus/bin/vp`, validated against that
-/// package's own `package.json` (`name === "vite-plus"`).
+/// The conventional `vp` launcher path for a project rooted at `dir`.
 ///
 /// Zed targets the real package launcher rather than the package manager's
 /// `node_modules/.bin/vp` shell shim, because pnpm stores bash scripts there
 /// that are not usable from Zed's headless WASM execution context.
+fn vp_launcher_path(dir: &Path) -> PathBuf {
+    dir.join("node_modules")
+        .join("vite-plus")
+        .join("bin")
+        .join("vp")
+}
+
+/// Probe [`vp_launcher_path`], validated against that package's own
+/// `package.json` (`name === "vite-plus"`). Used only where `node_modules`
+/// reads are reliable; see [`FileSystem::can_read_node_modules`].
 fn resolve_vp_at<F: FileSystem>(fs: &F, dir: &Path) -> Option<PathBuf> {
-    let pkg_dir = dir.join("node_modules").join("vite-plus");
-    let bin = pkg_dir.join("bin").join("vp");
+    let bin = vp_launcher_path(dir);
     if !fs.file_exists(&bin) {
         return None;
     }
+    let pkg_dir = dir.join("node_modules").join("vite-plus");
     let manifest = read_package_json(fs, &pkg_dir)?;
     (manifest["name"].as_str() == Some("vite-plus")).then_some(bin)
 }
@@ -130,7 +153,10 @@ enum Step<T> {
 ///    `package.json` that directly declares `vite-plus`. If none, return
 ///    `None` (not Vite+).
 /// 2. Walk up from that declaring directory (again bounded by the root
-///    workspace) for a project-scoped `node_modules/vite-plus/bin/vp`.
+///    workspace) for a project-scoped `node_modules/vite-plus/bin/vp`. When
+///    `node_modules` reads are unreliable (Zed; see
+///    [`FileSystem::can_read_node_modules`]) the conventional path at the
+///    declaring directory is trusted instead of probed.
 /// 3. Fall back to a `vp` on `$PATH` now that Vite+ is confirmed.
 ///
 /// Returns `Some(DetectResult { root, vp_path })`; `vp_path` is `None` when
@@ -146,10 +172,21 @@ pub fn detect_vite_plus_project<F: FileSystem>(fs: &F, start: &Path) -> Option<D
     })?;
 
     // Phase 2: resolve a project-scoped binary, bounded by the root workspace.
-    let vp_path = walk_up(fs, &root, |dir, _| match resolve_vp_at(fs, dir) {
-        Some(vp) => Step::Found(vp),
-        None => Step::Continue,
-    });
+    let vp_path = if fs.can_read_node_modules() {
+        // Reliable FS (Node extensions, tests): walk up read-verifying each
+        // candidate and validating it is a real `vite-plus` package.
+        walk_up(fs, &root, |dir, _| match resolve_vp_at(fs, dir) {
+            Some(vp) => Step::Found(vp),
+            None => Step::Continue,
+        })
+    } else {
+        // Zed: node_modules reads are unreliable, so trust the conventional
+        // path at the declaring directory. We cannot probe ancestors for a
+        // hoisted install (no reliable existence check), so we target the
+        // declaring directory only — the same `<root>/node_modules/...` path
+        // the extension uses today.
+        Some(vp_launcher_path(&root))
+    };
     if let Some(vp_path) = vp_path {
         return Some(DetectResult {
             root,
@@ -185,6 +222,7 @@ mod tests {
     struct FakeFs {
         files: BTreeMap<PathBuf, String>,
         path_vp: Option<PathBuf>,
+        unreliable_node_modules: bool,
     }
 
     impl FakeFs {
@@ -221,6 +259,12 @@ mod tests {
             self.path_vp = Some(PathBuf::from(path));
             self
         }
+
+        /// Model Zed: reads inside `node_modules` are unreliable (zed#10760).
+        fn unreliable_node_modules(mut self) -> Self {
+            self.unreliable_node_modules = true;
+            self
+        }
     }
 
     impl FileSystem for FakeFs {
@@ -234,6 +278,10 @@ mod tests {
 
         fn which(&self, binary: &str) -> Option<PathBuf> {
             (binary == "vp").then(|| self.path_vp.clone()).flatten()
+        }
+
+        fn can_read_node_modules(&self) -> bool {
+            !self.unreliable_node_modules
         }
     }
 
@@ -364,6 +412,30 @@ mod tests {
             .file("/repo/package.json", "{}")
             .declares("/repo/packages/app")
             .install("/repo");
+        assert_eq!(detect(&fs, "/repo"), None);
+    }
+
+    #[test]
+    fn zed_mode_trusts_constructed_vp_path() {
+        // Zed cannot reliably read node_modules, so even with NO visible
+        // install files the detector trusts the conventional path once the
+        // root package.json (reliably readable) declares vite-plus.
+        let fs = FakeFs::default()
+            .declares("/repo")
+            .unreliable_node_modules();
+        assert_eq!(
+            detect(&fs, "/repo"),
+            runnable("/repo", "/repo/node_modules/vite-plus/bin/vp"),
+        );
+    }
+
+    #[test]
+    fn zed_mode_plain_project_is_still_null() {
+        // Phase 1 reads the root package.json, which IS reliable in Zed; a
+        // plain project is still correctly rejected.
+        let fs = FakeFs::default()
+            .file("/repo/package.json", r#"{ "dependencies": {} }"#)
+            .unreliable_node_modules();
         assert_eq!(detect(&fs, "/repo"), None);
     }
 

--- a/src/vite_plus.rs
+++ b/src/vite_plus.rs
@@ -31,10 +31,6 @@ pub trait FileSystem {
     /// Whether a regular file exists at `path`.
     fn file_exists(&self, path: &Path) -> bool;
 
-    /// Resolves a binary by name on `$PATH` (RFC Phase 3). `None` when the
-    /// binary is absent or `$PATH` lookup is unavailable in this environment.
-    fn which(&self, binary: &str) -> Option<PathBuf>;
-
     /// Whether reads inside `node_modules` are reliable.
     ///
     /// Zed's WASM API cannot reliably read there ([zed#10760]) and `Path::exists`
@@ -147,20 +143,24 @@ enum Step<T> {
 }
 
 /// Detects whether `start` lives in a Vite+ project and, if so, locates a
-/// runnable `vp`. Implements the three RFC phases:
+/// project-scoped `vp`. Implements two phases:
 ///
 /// 1. Walk up from `start` to the root workspace looking for the first
 ///    `package.json` that directly declares `vite-plus`. If none, return
 ///    `None` (not Vite+).
-/// 2. Walk up from that declaring directory (again bounded by the root
-///    workspace) for a project-scoped `node_modules/vite-plus/bin/vp`. When
-///    `node_modules` reads are unreliable (Zed; see
-///    [`FileSystem::can_read_node_modules`]) the conventional path at the
-///    declaring directory is trusted instead of probed.
-/// 3. Fall back to a `vp` on `$PATH` now that Vite+ is confirmed.
+/// 2. Resolve a project-scoped `node_modules/vite-plus/bin/vp`. With reliable
+///    `node_modules` reads, walk up from the declaring directory (bounded by
+///    the root workspace) read-verifying each candidate; in Zed (unreliable
+///    reads; see [`FileSystem::can_read_node_modules`]) trust the conventional
+///    path at the declaring directory.
+///
+/// The RFC's Phase 3 (a global `vp` on `$PATH`) is deliberately not
+/// implemented: a missing install breaks `vp` regardless of binary source
+/// (the project's `vite.config.ts` imports `vite-plus`), so a global fallback
+/// cannot rescue it.
 ///
 /// Returns `Some(DetectResult { root, vp_path })`; `vp_path` is `None` when
-/// `vite-plus` is declared but no runnable `vp` exists anywhere reachable.
+/// `vite-plus` is declared but no project-scoped `vp` was found.
 pub fn detect_vite_plus_project<F: FileSystem>(fs: &F, start: &Path) -> Option<DetectResult> {
     // Phase 1: find the package.json that DIRECTLY declares vite-plus.
     let root = walk_up(fs, start, |dir, pkg| {
@@ -187,27 +187,8 @@ pub fn detect_vite_plus_project<F: FileSystem>(fs: &F, start: &Path) -> Option<D
         // the extension uses today.
         Some(vp_launcher_path(&root))
     };
-    if let Some(vp_path) = vp_path {
-        return Some(DetectResult {
-            root,
-            vp_path: Some(vp_path),
-        });
-    }
 
-    // Phase 3: fall back to a global vp now that Vite+ is confirmed.
-    // Unlike the RFC's note, Zed *can* do this: `Worktree::which` exposes a
-    // `$PATH` lookup. See the module-level docs.
-    if let Some(vp) = fs.which("vp") {
-        return Some(DetectResult {
-            root,
-            vp_path: Some(vp),
-        });
-    }
-
-    Some(DetectResult {
-        root,
-        vp_path: None,
-    })
+    Some(DetectResult { root, vp_path })
 }
 
 #[cfg(test)]
@@ -216,12 +197,10 @@ mod tests {
     use std::collections::BTreeMap;
 
     /// In-memory filesystem for the conformance fixtures. A path is present
-    /// in `files` iff it exists; readable files also carry contents. `which`
-    /// models a `vp` on `$PATH`.
+    /// in `files` iff it exists; readable files also carry contents.
     #[derive(Default)]
     struct FakeFs {
         files: BTreeMap<PathBuf, String>,
-        path_vp: Option<PathBuf>,
         unreliable_node_modules: bool,
     }
 
@@ -255,11 +234,6 @@ mod tests {
             self.file(&format!("{dir}/{file}"), "")
         }
 
-        fn vp_on_path(mut self, path: &str) -> Self {
-            self.path_vp = Some(PathBuf::from(path));
-            self
-        }
-
         /// Model Zed: reads inside `node_modules` are unreliable (zed#10760).
         fn unreliable_node_modules(mut self) -> Self {
             self.unreliable_node_modules = true;
@@ -274,10 +248,6 @@ mod tests {
 
         fn file_exists(&self, path: &Path) -> bool {
             self.files.contains_key(path)
-        }
-
-        fn which(&self, binary: &str) -> Option<PathBuf> {
-            (binary == "vp").then(|| self.path_vp.clone()).flatten()
         }
 
         fn can_read_node_modules(&self) -> bool {
@@ -343,17 +313,10 @@ mod tests {
     }
 
     #[test]
-    fn root_declared_no_local_no_global() {
+    fn root_declared_but_not_installed() {
+        // Declared, no project-scoped install: declared-but-not-installed.
         let fs = FakeFs::default().declares("/repo");
         assert_eq!(detect(&fs, "/repo"), declared_only("/repo"));
-    }
-
-    #[test]
-    fn root_declared_no_local_global_on_path() {
-        let fs = FakeFs::default()
-            .declares("/repo")
-            .vp_on_path("/usr/local/bin/vp");
-        assert_eq!(detect(&fs, "/repo"), runnable("/repo", "/usr/local/bin/vp"));
     }
 
     #[test]
@@ -362,15 +325,6 @@ mod tests {
         let fs = FakeFs::default()
             .file("/repo/package.json", "{}")
             .install("/repo");
-        assert_eq!(detect(&fs, "/repo"), None);
-    }
-
-    #[test]
-    fn global_vp_without_declaration() {
-        // Phase 1 fails, so Phase 3 (the $PATH vp) must never run.
-        let fs = FakeFs::default()
-            .file("/repo/package.json", "{}")
-            .vp_on_path("/usr/local/bin/vp");
         assert_eq!(detect(&fs, "/repo"), None);
     }
 
@@ -394,7 +348,7 @@ mod tests {
 
     #[test]
     fn yarn4_pnp() {
-        // Berry/PnP: declared, but no node_modules and no global vp.
+        // Berry/PnP: declared, but no node_modules install.
         let fs = FakeFs::default().declares("/repo");
         assert_eq!(detect(&fs, "/repo"), declared_only("/repo"));
     }


### PR DESCRIPTION
## What

POC of the editor-extension detection rule from the Vite+ RFC [voidzero-dev/vite-plus#1614](https://github.com/voidzero-dev/vite-plus/pull/1614) ("Vite+ Project Detection for Editor Extensions").

> **Draft, do not merge.** This tracks a *draft* RFC, and its premise (vite-plus dropping the `bin/oxlint` / `bin/oxfmt` wrappers) lands in vite-plus#1557, which has not shipped. Opening this to validate the approach and feed findings back to the RFC.

## Why

Today oxc-zed implicitly relies on vite-plus's per-package `bin/oxlint` / `bin/oxfmt` wrappers: when a project declares `vite-plus`, `lsp.rs` launches `node node_modules/vite-plus/bin/oxlint --lsp`. vite-plus#1557 removes those wrappers, which **breaks the current extension**. The RFC's fix: each editor explicitly detects a Vite+ project and launches `vp lint --lsp` / `vp fmt --lsp` instead.

## How

- **`src/vite_plus.rs`**: the RFC algorithm ported to Rust behind a small `FileSystem` trait so the core logic is host-testable. Unit tests cover the RFC conformance fixtures plus edge cases. 13 tests, all green.
  - Phase 1: walk up for the first `package.json` that *directly* declares `vite-plus`, bounded by the root workspace.
  - Phase 2: project-scoped `node_modules/vite-plus/bin/vp` (Zed targets the real launcher, not the pnpm `.bin/vp` shell shim).
  - The RFC's Phase 3 (a global `vp` on `$PATH`) is **deliberately not implemented**, see finding 2.
- **`src/lsp.rs`**: a `WorktreeFs` adapter backs the `FileSystem` trait with Zed's `Worktree`. `oxlint`/`oxfmt` launch `vp <lint|fmt> --lsp` when Vite+ is detected, and fall back to plain `oxlint`/`oxfmt` otherwise.

## Findings for the RFC

1. **`node_modules` reads are unreliable in Zed, the RFC's Phase 2 "validate against a real `vite-plus` package (`name === "vite-plus"`)" is not portable to Zed.** [zed#10760](https://github.com/zed-industries/zed/issues/10760) (closed *not planned*) confirms `Worktree::read_text_file` on `node_modules` "works sometimes but mostly doesn't," and `Path::exists` doesn't work in the WASM sandbox. The shipping extension already sidesteps this by reading only the root `package.json` and **constructing-and-trusting** the binary path. So this POC trusts `node_modules/vite-plus/bin/vp` rather than read-verifying it; a missing install surfaces as a clear `Cannot find module …/vite-plus/bin/vp` ("run `pnpm install`").
2. **Phase 3 is implementable but low-value in Zed, so it's omitted.** The RFC says Zed "exposes neither `$PATH` nor a process-spawn capability," but `Worktree::which` / `shell_env` have existed since WIT v0.0.1, so a `$PATH` lookup *does* work. However, live testing showed it can't actually help: a real project's `vite.config.ts` imports `vite-plus`, so with no local install `vp` (global or not) dies with `UNRESOLVED_IMPORT`; a missing `node_modules` breaks `vp` regardless of binary source. So this POC deliberately uses a **local-only** design with no global fallback (the `which` lookup was prototyped, then removed).
3. **The real Phase-1 limitation is the upward walk.** `Worktree::read_text_file` is confined to the worktree, so Phase 1 cannot read above `worktree.root_path()`. Opening a monorepo root where only a *subpackage* declares `vite-plus` returns `null`, the single-root gap the RFC already acknowledges for Zed. Captured by `zed_worktree_root_misses_subpackage_declaration`.

## Verification

`cargo fmt --check`, `cargo check --all-targets`, `cargo test` (13/13), `cargo clippy -D warnings`, `cargo doc -D warnings`, and `cargo build --release --target wasm32-wasip2` all pass.

**Live smoke test in Zed 1.4.4** (dev extension): verified against a real vite-plus project (`node-modules/urllib`), Zed's LSP log shows `node …/urllib/node_modules/vite-plus/bin/vp lint --lsp` and `… fmt --lsp`, with the servers running. A non-Vite+ project launches plain `oxfmt --lsp`. Deleting `node_modules` produces the expected `Cannot find module …/vite-plus/bin/vp` (vp needs the install regardless, see finding 2).

## Open / out of scope

- "Declared but not installed" UX is a silent fallback + debug log (RFC open question #2). In Zed, because installs can't be verified, this state mostly can't be detected, so a missing `vp` surfaces at spawn time instead.
- Phase 1/2 stay at the worktree root in Zed (no per-file resolution available in the WASM API).

